### PR TITLE
Make backgrounds transparent

### DIFF
--- a/app/clientes/page.tsx
+++ b/app/clientes/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function ClientesPage() {
   return (
-    <div className="min-h-screen bg-background text-foreground pt-20 px-4">
+    <div className="min-h-screen bg-transparent text-foreground pt-20 px-4">
       <div className="max-w-4xl mx-auto mb-16 text-center">
         {/* Se aplica gradiente azul corporativo para mantener coherencia visual con el resto de títulos principales */}
         <h1 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-to-r from-primary/70 to-primary bg-clip-text text-transparent">Empresas que confían en ControlDoc</h1>

--- a/app/equipo/page.tsx
+++ b/app/equipo/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function EquipoPage() {
   return (
-    <div className="min-h-screen bg-background text-foreground pt-20 px-4">
+    <div className="min-h-screen bg-transparent text-foreground pt-20 px-4">
       <div className="max-w-4xl mx-auto mb-16 text-center">
         {/* Gradiente azul corporativo para coherencia visual */}
         <h1 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-to-r from-primary/70 to-primary bg-clip-text text-transparent">Nuestro Equipo</h1>

--- a/app/precios/page.tsx
+++ b/app/precios/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function PreciosPage() {
   return (
-    <div className="min-h-screen pt-20 px-4 bg-background text-foreground">
+    <div className="min-h-screen pt-20 px-4 bg-transparent text-foreground">
       <div className="max-w-5xl mx-auto mb-1 text-center">
         <h1 className="text-5xl md:text-5xl font-bold mb-4">Planes y Precios</h1>
         <p className="text-muted-foreground text-lg">

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -34,7 +34,7 @@ export default function Contact() {
                   id="name"
                   value={formData.name}
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="w-full px-4 py-3  border border-cyan-500/20 rounded-lg focus:border-cyan-500 focus:outline-none transition-colors"
+                  className="w-full px-4 py-3 bg-white/30 dark:bg-black/30 border border-cyan-500/20 rounded-lg focus:border-cyan-500 focus:outline-none transition-colors"
                   required
                 />
               </div>
@@ -47,7 +47,7 @@ export default function Contact() {
                   id="email"
                   value={formData.email}
                   onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                  className="w-full px-4 py-3 bg-gray-900/50 border border-cyan-500/20 rounded-lg focus:border-cyan-500 focus:outline-none transition-colors"
+                  className="w-full px-4 py-3 bg-white/30 dark:bg-black/30 border border-cyan-500/20 rounded-lg focus:border-cyan-500 focus:outline-none transition-colors"
                   required
                 />
               </div>
@@ -60,7 +60,7 @@ export default function Contact() {
                   rows={5}
                   value={formData.message}
                   onChange={(e) => setFormData({ ...formData, message: e.target.value })}
-                  className="w-full px-4 py-3 bg-gray-900/50 border border-cyan-500/20 rounded-lg focus:border-cyan-500 focus:outline-none transition-colors resize-none"
+                  className="w-full px-4 py-3 bg-white/30 dark:bg-black/30 border border-cyan-500/20 rounded-lg focus:border-cyan-500 focus:outline-none transition-colors resize-none"
                   required
                 />
               </div>

--- a/components/InfraestructuraCarousel.tsx
+++ b/components/InfraestructuraCarousel.tsx
@@ -36,7 +36,7 @@ export default function InfraestructuraCarousel() {
       <CarouselContent>
         {providers.map((item, index) => (
           <CarouselItem key={index}>
-            <div className="p-6 rounded-xl border bg-white dark:bg-zinc-900 shadow flex flex-col items-center text-center space-y-3">
+            <div className="p-6 rounded-xl border bg-white/80 dark:bg-black/60 shadow flex flex-col items-center text-center space-y-3">
               <Image
                 src={item.logo}
                 alt={item.name}

--- a/components/layout/AccessibleHeader.tsx
+++ b/components/layout/AccessibleHeader.tsx
@@ -65,7 +65,7 @@ export default function AccessibleHeader() {
   }, [isOpen])
 
   return (
-    <header className="fixed w-full top-0 z-50 bg-black/90 backdrop-blur-sm border-b border-cyan-500/20">
+    <header className="fixed w-full top-0 z-50 bg-black/60 backdrop-blur-sm border-b border-cyan-500/20">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <Link

--- a/components/legal.tsx
+++ b/components/legal.tsx
@@ -14,7 +14,7 @@ const Legal = () => {
           En ControlDoc, tu privacidad es nuestra prioridad. Esta Política de Privacidad describe cómo recopilamos, usamos y protegemos tu información personal cuando utilizas nuestros servicios. Al acceder a nuestra plataforma, aceptas las prácticas descritas en este documento.
         </p>
 
-        <section className="mb-8 p-6 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+        <section className="mb-8 p-6 bg-white/80 dark:bg-black/60 rounded-lg border border-gray-200 dark:border-gray-700">
           <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-gray-100">1. Protección y Tratamiento de Datos Personales</h2>
           <p className="mb-4">
             Nos comprometemos a proteger tus datos y a utilizarlos de manera responsable. Solo recopilamos la información estrictamente necesaria para ofrecer y mejorar nuestros servicios.
@@ -25,7 +25,7 @@ const Legal = () => {
           </ul>
         </section>
 
-        <section className="mb-8 p-6 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+        <section className="mb-8 p-6 bg-white/80 dark:bg-black/60 rounded-lg border border-gray-200 dark:border-gray-700">
           <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-gray-100">2. Finalidad del Uso de la Información</h2>
           <p className="mb-4">
             La información recopilada se utiliza para los siguientes propósitos:
@@ -37,7 +37,7 @@ const Legal = () => {
           </ul>
         </section>
 
-        <section className="mb-8 p-6 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+        <section className="mb-8 p-6 bg-white/80 dark:bg-black/60 rounded-lg border border-gray-200 dark:border-gray-700">
           <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-gray-100">3. Uso de Cookies</h2>
           <p className="mb-4">
             Utilizamos cookies para personalizar tu experiencia y para análisis estadístico. Puedes gestionar tus preferencias de cookies desde la configuración de tu navegador.
@@ -47,14 +47,14 @@ const Legal = () => {
           </ul>
         </section>
 
-        <section className="mb-8 p-6 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+        <section className="mb-8 p-6 bg-white/80 dark:bg-black/60 rounded-lg border border-gray-200 dark:border-gray-700">
           <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-gray-100">4. Enlaces a Sitios de Terceros</h2>
           <p className="mb-4">
             Nuestra plataforma puede incluir enlaces a sitios web de terceros. No nos hacemos responsables de sus políticas de privacidad ni de su contenido. Te recomendamos leer sus políticas antes de proporcionar cualquier dato.
           </p>
         </section>
 
-        <section className="mb-8 p-6 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+        <section className="mb-8 p-6 bg-white/80 dark:bg-black/60 rounded-lg border border-gray-200 dark:border-gray-700">
           <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-gray-100">5. Control sobre tu Información</h2>
           <p className="mb-4">
             Tienes pleno control sobre tu información personal. En cualquier momento, puedes ejercer tus derechos de acceso, rectificación, cancelación y oposición (ARCO).
@@ -65,7 +65,7 @@ const Legal = () => {
           </ul>
         </section>
 
-        <section className="p-6 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+        <section className="p-6 bg-white/80 dark:bg-black/60 rounded-lg border border-gray-200 dark:border-gray-700">
           <h2 className="text-2xl font-semibold mb-4 text-gray-900 dark:text-gray-100">6. Modificaciones a esta Política</h2>
           <p>
             ControlDoc se reserva el derecho de modificar esta Política de Privacidad en cualquier momento. Cualquier cambio será notificado a través de nuestra plataforma. Te recomendamos revisar esta página periódicamente para estar informado.

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -18,7 +18,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/60  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-white/80 dark:bg-black/60 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -8,7 +8,7 @@ const alertVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-background text-foreground",
+        default: "bg-white/80 dark:bg-black/60 text-foreground",
         destructive:
           "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
       },

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-lg border bg-white/80 dark:bg-black/60 text-card-foreground shadow-sm",
       className
     )}
     {...props}

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -179,7 +179,7 @@ const ChartTooltipContent = React.forwardRef<
       <div
         ref={ref}
         className={cn(
-          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-white/80 dark:bg-black/60 px-2.5 py-1.5 text-xs shadow-xl",
           className
         )}
       >

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/60  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-white/80 dark:bg-black/60 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -28,7 +28,7 @@ const DrawerOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Overlay
     ref={ref}
-    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    className={cn("fixed inset-0 z-50 bg-black/60", className)}
     {...props}
   />
 ))
@@ -43,12 +43,12 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-white/80 dark:bg-black/60",
         className
       )}
       {...props}
     >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-white/80 dark:bg-black/60" />
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-white/80 dark:bg-black/60 p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-white/80 dark:bg-black/60 p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-white/80 dark:bg-black/60 px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-white/80 dark:bg-black/60 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -21,7 +21,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/60  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -31,7 +31,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed z-50 gap-4 bg-white/80 dark:bg-black/60 p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
   {
     variants: {
       side: {
@@ -65,7 +65,7 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-white/80 data-[state=open]:dark:bg-black/60">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}


### PR DESCRIPTION
## Summary
- set pages to use transparent main backgrounds
- lighten overlays and content in Drawer, Dialog, AlertDialog and Sheet
- adjust inputs, textareas, selects and dropdowns for translucent backgrounds
- use translucent cards, alerts and chart tooltip
- tweak legal sections and other components for transparency
- soften header background

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68621aca68488325a12ffcfc36a6e270